### PR TITLE
[Design] toast 색상 변경

### DIFF
--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,8 +1,18 @@
-import 'react-toastify/dist/ReactToastify.css';
 import { toast, ToastContainer } from 'react-toastify';
 import styled from '@emotion/styled';
 
 export type toastType = 'success' | 'failed';
+
+const CustomIconBlue = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="#4a95f2">
+    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
+  </svg>
+);
+const CustomIconRed = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="#f44336">
+    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
+  </svg>
+);
 
 export function ShowToast(message: string, toastType = 'success') {
   if (toastType === 'success') {
@@ -10,12 +20,14 @@ export function ShowToast(message: string, toastType = 'success') {
       autoClose: 3000,
       theme: 'light',
       draggable: true,
+      icon: <CustomIconBlue />,
     });
   } else {
     toast.error(`${message}`, {
       autoClose: 3000,
       theme: 'light',
       draggable: true,
+      icon: <CustomIconRed />,
     });
   }
 }
@@ -29,14 +41,13 @@ export const StyledToastContainer = styled(ToastContainer)`
     background-color: white;
     color: black;
   }
-  /* .toastify-icon-color-success {
+  .toastify-icon-color-success {
     fill: #3498db;
-  } */
-  /* .Toastify__toast--success {
+  }
+  .Toastify__toast--success {
     fill: #3498db;
-  } */
-  /* .Toastify__progress-bar {
+  }
+  .Toastify__progress-bar--success {
     background-color: #4a95f2;
-    color: #4a95f2;
-  } */
+  }
 `;

--- a/src/pages/MyCreatedTravel.tsx
+++ b/src/pages/MyCreatedTravel.tsx
@@ -6,6 +6,7 @@ import { Outlet } from 'react-router-dom';
 const MyCreatedTravel = () => {
   const { selectedTab } = useTabStore();
   const managePage = location.pathname.startsWith('/my-page/my-created-travel/manage-my-travel/');
+
   return (
     <div>
       {managePage ? null : (


### PR DESCRIPTION
- 성공시 파란색으로
- 실패시 빨간색 개열 색상으로 깔맞춤

## 📋 작업 세부 사항

<!-- 변경 사항이나 추가된 기능에 대해 자세히 설명해 주세요. -->

## 🔧 변경 사항 요약

<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- ## 📸 스크린샷 (선택 사항) -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 토스트 알림에 맞춤형 아이콘 추가
  - 성공 및 실패 상태에 따른 아이콘 및 스타일 변경

- **스타일**
  - 토스트 알림의 CSS 스타일 업데이트
  - 성공 토스트의 색상 및 진행 표시줄 스타일 개선

- **페이지 변경**
  - 내가 만든 여행 페이지의 조건부 렌더링 로직 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->