### PR TITLE
[Feat] 신청한 유저 상태변경 api 및 재확인모달 적용

### DIFF
--- a/src/api/manageTravel/patchUserStatus.ts
+++ b/src/api/manageTravel/patchUserStatus.ts
@@ -1,0 +1,22 @@
+import axios from 'axios';
+
+const SERVER = import.meta.env.VITE_SERVER_URL;
+
+const patchUserStatus = async (
+  teamId: string,
+  userId: string,
+  status: string,
+): Promise<boolean | Error> => {
+  try {
+    const response = await axios.patch(`${SERVER}/api/v1/users/update-user-status`, {
+      teamId,
+      userId,
+      status,
+    });
+    return response.data.success;
+  } catch (err) {
+    throw new Error(err instanceof Error ? err.message : '유저 상태 변경 실패');
+  }
+};
+
+export default patchUserStatus;

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -7,7 +7,7 @@ import { theme } from '@/styles/theme';
 interface ConfirmModalProps {
   modalId: string;
   trigger: React.ReactNode;
-  message: string;
+  message: string | React.ReactNode;
   onConfirm?: () => void;
 }
 
@@ -19,7 +19,7 @@ const ConfirmModal = ({ modalId, trigger, message, onConfirm }: ConfirmModalProp
   return (
     <Modal open={isModalOpen} trigger={trigger}>
       <div css={wrapper}>
-        <p>{message}</p>
+        {typeof message === 'string' ? <p>{message}</p> : <div css={customMessage}>{message}</div>}
         <div css={{ display: 'flex', gap: '20px' }}>
           <FiledBtn color={theme.colors.primary} size={'mdHeight'} onClick={onConfirm}>
             예
@@ -47,4 +47,10 @@ const wrapper = css`
     font-weight: 500;
     color: #333;
   }
+`;
+
+const customMessage = css`
+  display: flex;
+  align-items: center;
+  flex-direction: column;
 `;

--- a/src/components/manageMyTravel/TravelTeam.tsx
+++ b/src/components/manageMyTravel/TravelTeam.tsx
@@ -14,15 +14,22 @@ interface TravelTeamProps {
   travelId: string;
   teamId: string;
   isOngoing: boolean;
+  hasAccount: boolean;
   handleHasData: (hasData: boolean) => void;
 }
 
-const TravelTeam = ({ travelId, teamId, isOngoing, handleHasData }: TravelTeamProps) => {
+const TravelTeam = ({
+  travelId,
+  teamId,
+  isOngoing,
+  hasAccount,
+  handleHasData,
+}: TravelTeamProps) => {
   const pageContainer = usePageStore((state) => state.pageContainer);
-  const currentTeam = pageContainer.find((page) => page.paginationId === teamId);
+  const currentPage = pageContainer.find((page) => page.paginationId === teamId)?.currentPage || 1;
   const { data: teamData } = useGetManageTravelTeams(
     travelId,
-    currentTeam?.currentPage || 1,
+    currentPage,
     MANAGE_COUNT_PER_PAGE,
     teamId,
   );
@@ -44,7 +51,7 @@ const TravelTeam = ({ travelId, teamId, isOngoing, handleHasData }: TravelTeamPr
           <Team max={teamData.personLimit} mbtiList={userMBTIList} />
           {teamData.appliedUsers ? (
             <div>
-              <UserTable data={teamData.appliedUsers} />
+              <UserTable data={teamData.appliedUsers} teamId={teamId} hasAccount={hasAccount} />
               <MultiPagination pageData={teamData.pagination} teamId={teamData.teamId} />
             </div>
           ) : (

--- a/src/components/manageMyTravel/UserStatusWaiting.tsx
+++ b/src/components/manageMyTravel/UserStatusWaiting.tsx
@@ -1,0 +1,81 @@
+import ConfirmModal from '../ConfirmModal';
+import FiledBtn from '../FiledBtn';
+import useModalStore from '@/stores/useModalStore';
+import usePatchUserStatus from '@/hooks/query/usePatchUserStatus';
+import { modalId } from '@/constants/modalId';
+import { theme } from '@/styles/theme';
+import { useNavigate } from 'react-router-dom';
+import usePageStore from '@/stores/usePageStore';
+
+interface UserStatusWaitingProps {
+  teamId: string;
+  userId: string;
+  userName: string;
+  hasAccount: boolean;
+}
+
+const UserStatusWaiting = ({ teamId, userId, userName, hasAccount }: UserStatusWaitingProps) => {
+  const pageContainer = usePageStore((state) => state.pageContainer);
+  const currentPage = pageContainer.find((page) => page.paginationId === teamId)?.currentPage || 1;
+  const navigate = useNavigate();
+  const setModalName = useModalStore((state) => state.setModalName);
+  const { mutate } = usePatchUserStatus(teamId, currentPage, userName);
+
+  const handleApproveConfirm = () => {
+    if (!hasAccount) {
+      setModalName(null);
+      navigate('/my-page/my-account');
+    } else {
+      handleUserStatus(userId, 'approved');
+    }
+  };
+
+  const handleUserStatus = (userId: string, newStatus: string) => {
+    mutate({ userId: userId, status: newStatus });
+  };
+
+  return (
+    <div css={{ display: 'flex', gap: '5px' }}>
+      <ConfirmModal
+        modalId={`${modalId.my.manageUserStatusApprove}-${userId}`}
+        message={
+          hasAccount ? (
+            `정말 ${userName}님을 승인 하시겠습니까?`
+          ) : (
+            <>
+              <p>등록된 계좌가 없습니다. </p>
+              <p>마이페이지에서 등록하시겠습니까?</p>
+            </>
+          )
+        }
+        onConfirm={handleApproveConfirm}
+        trigger={
+          <FiledBtn
+            onClick={() => setModalName(`${modalId.my.manageUserStatusApprove}-${userId}`)}
+            color={theme.colors.primary}
+            size={'sm'}
+          >
+            승인
+          </FiledBtn>
+        }
+      />
+
+      <ConfirmModal
+        modalId={`${modalId.my.manageUserStatusReject}-${userId}`}
+        message={`정말 ${userName}님을 거절 하시겠습니까?`}
+        onConfirm={() => handleUserStatus(userId, 'rejected')}
+        trigger={
+          <FiledBtn
+            onClick={() => setModalName(`${modalId.my.manageUserStatusReject}-${userId}`)}
+            color={'#d7d7d7'}
+            size="sm"
+          >
+            거절
+          </FiledBtn>
+        }
+      />
+    </div>
+  );
+};
+
+export default UserStatusWaiting;

--- a/src/components/manageMyTravel/UserTable.tsx
+++ b/src/components/manageMyTravel/UserTable.tsx
@@ -1,14 +1,16 @@
 import { css } from '@emotion/react';
 import { ApplicationUserData } from '@/types/travelDataType';
 import Profile from '@/components/Profile';
-import FiledBtn from '@/components/FiledBtn';
 import { formatDate } from '@/utils/format';
+import UserStatusWaiting from './UserStatusWaiting';
 
 interface UserTableProps {
   data: ApplicationUserData[];
+  teamId: string;
+  hasAccount: boolean;
 }
 
-const UserTable = ({ data }: UserTableProps) => {
+const UserTable = ({ data, teamId, hasAccount }: UserTableProps) => {
   return (
     <table css={tableWrapper}>
       <thead>
@@ -35,14 +37,12 @@ const UserTable = ({ data }: UserTableProps) => {
             <td>{formatDate(user.appliedAt)}</td>
             <td css={{ minWidth: '145px' }}>
               {user.status === 'waiting' ? (
-                <div css={{ display: 'flex', gap: '5px' }}>
-                  <FiledBtn color={'#4A95F2'} size={'sm'}>
-                    승인
-                  </FiledBtn>
-                  <FiledBtn color={'#d7d7d7'} size={'sm'}>
-                    거절
-                  </FiledBtn>
-                </div>
+                <UserStatusWaiting
+                  teamId={teamId}
+                  userId={user.userId}
+                  userName={user.userName}
+                  hasAccount={hasAccount}
+                />
               ) : user.status === 'approved' ? (
                 '승인'
               ) : (

--- a/src/constants/modalId.ts
+++ b/src/constants/modalId.ts
@@ -5,5 +5,7 @@ export const modalId = {
   my: {
     travelDelete: 'my-travel-delete',
     manageActiveStatus: 'manage-active-status',
+    manageUserStatusApprove: 'manage-user-status-approve',
+    manageUserStatusReject: 'manage-user-status-reject',
   },
 } as const;

--- a/src/hooks/query/usePatchUserStatus.ts
+++ b/src/hooks/query/usePatchUserStatus.ts
@@ -1,0 +1,47 @@
+import patchUserStatus from '@/api/manageTravel/patchUserStatus';
+import { ShowToast } from '@/components/Toast';
+import { MANAGE_TRAVEL_TEAMS } from '@/constants/queyKey';
+import useModalStore from '@/stores/useModalStore';
+import { TravelTeamData } from '@/types/travelDataType';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+interface UsePatchUserStatusProps {
+  userId: string;
+  status: string;
+}
+
+const usePatchUserStatus = (teamId: string, page: number, userName: string) => {
+  const setModalName = useModalStore((state) => state.setModalName);
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ userId, status }: UsePatchUserStatusProps) =>
+      patchUserStatus(teamId, userId, status),
+    onMutate: ({ userId, status }) => {
+      const prevData: TravelTeamData | undefined = queryClient.getQueryData([
+        MANAGE_TRAVEL_TEAMS,
+        page,
+        teamId,
+      ]);
+      queryClient.setQueryData([MANAGE_TRAVEL_TEAMS, page, teamId], (oldData: TravelTeamData) => ({
+        ...oldData,
+        appliedUsers: prevData?.appliedUsers?.map((user) =>
+          user.userId === userId ? { ...user, status } : user,
+        ),
+      }));
+      return { prevData };
+    },
+    onSuccess: (_, { status }) => {
+      setModalName(null);
+      ShowToast(`${userName}님이 ${status === 'approved' ? '승인' : '거절'}되었습니다.`, 'success');
+    },
+    onError: (_err, _, context) => {
+      if (context?.prevData) {
+        queryClient.setQueryData([MANAGE_TRAVEL_TEAMS, page, teamId], context.prevData);
+      }
+      setModalName(null);
+      ShowToast('상태 변경이 실패되었습니다. 다시 시도해주세요', 'failed');
+    },
+  });
+};
+
+export default usePatchUserStatus;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import { createRoot } from 'react-dom/client';
 import App from '@/App.tsx';
 import GlobalStyles from '@/styles/GlobalStyles';
 import { theme, muiTheme } from '@/styles/theme';
+import Toast from './components/Toast';
 
 const queryClient = new QueryClient();
 
@@ -16,6 +17,7 @@ createRoot(document.getElementById('root')!).render(
         <QueryClientProvider client={queryClient}>
           <GlobalStyles />
           <App />
+          <Toast />
         </QueryClientProvider>
       </EmotionThemeProvider>
     </MUIThemeProvider>

--- a/src/pages/ManageMyTravel.tsx
+++ b/src/pages/ManageMyTravel.tsx
@@ -42,6 +42,7 @@ const ManageMyTravel = () => {
               travelId={travelId}
               teamId={teamId}
               isOngoing={isOngoingTab}
+              hasAccount={typeof travelData.accountNumber === 'string'}
               handleHasData={handleHasData}
             />
           ))}

--- a/src/types/travelDataType.ts
+++ b/src/types/travelDataType.ts
@@ -15,6 +15,7 @@ export interface TravelData {
   updateAt: string;
   teamTeams: string[];
   travelActive: boolean;
+  accountNumber: string | null;
 }
 export interface TravelTeamData {
   teamId: string;


### PR DESCRIPTION
## 📋 작업 세부 사항

신청한 유저 상태변경 api 및 재확인모달 적용

## 🔧 변경 사항 요약

- 신청한 유저 상태변경 api 추가 및 적용
- 상태변경 전 재확인 모달 적용
- 계좌번호 없을 시 마이페이지로 이동되도록 
- 토스트컴포넌트 App컴포넌트와 같은 위치에 추가
- 컨펌모달 message JSX문도 받을 수 있도록 확장




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 여행 팀 관리 기능 개선
	- 사용자 상태 승인/거절 모달 추가
	- 토스트 알림 기능 도입

- **버그 수정**
	- 사용자 상태 업데이트 로직 개선
	- 모달 메시지 렌더링 로직 수정

- **기타 변경사항**
	- 여행 데이터 타입에 계정 번호 속성 추가
	- 모달 ID 상수 확장

<!-- end of auto-generated comment: release notes by coderabbit.ai -->