### PR TITLE
[Feat] 댓글 수정, 삭제 기능 추가

### DIFF
--- a/src/api/findGuideDetail/deleteComment.ts
+++ b/src/api/findGuideDetail/deleteComment.ts
@@ -1,11 +1,9 @@
 import { SERVER } from '@/constants/url';
 import axios from 'axios';
 
-const deleteComment = async (commentId: string, userId: string): Promise<boolean> => {
+const deleteComment = async (commentId: string): Promise<boolean> => {
   try {
-    const response = await axios.delete(`${SERVER}/api/v1/travels-guide/comments`, {
-      data: { commentId, userId },
-    });
+    const response = await axios.delete(`${SERVER}/api/v1/travels-guide/comments/${commentId}`);
     return response.data.success;
   } catch (err) {
     throw new Error(err instanceof Error ? err.message : '댓글 삭제 실패');

--- a/src/api/findGuideDetail/deleteComment.ts
+++ b/src/api/findGuideDetail/deleteComment.ts
@@ -1,0 +1,15 @@
+import { SERVER } from '@/constants/url';
+import axios from 'axios';
+
+const deleteComment = async (commentId: string, userId: string): Promise<boolean> => {
+  try {
+    const response = await axios.delete(`${SERVER}/api/v1/travels-guide/comments`, {
+      data: { commentId, userId },
+    });
+    return response.data.success;
+  } catch (err) {
+    throw new Error(err instanceof Error ? err.message : '댓글 삭제 실패');
+  }
+};
+
+export default deleteComment;

--- a/src/api/findGuideDetail/patchComment.ts
+++ b/src/api/findGuideDetail/patchComment.ts
@@ -1,0 +1,21 @@
+import { SERVER } from '@/constants/url';
+import axios from 'axios';
+
+const patchComment = async (
+  commentId: string,
+  userId: string,
+  comment: string,
+): Promise<boolean> => {
+  try {
+    const response = await axios.patch(`${SERVER}/api/v1/travels-guide/comments`, {
+      commentId,
+      userId,
+      comment,
+    });
+    return response.data.success;
+  } catch (err) {
+    throw new Error(err instanceof Error ? err.message : '댓글 수정 실패');
+  }
+};
+
+export default patchComment;

--- a/src/api/findGuideDetail/postComment.ts
+++ b/src/api/findGuideDetail/postComment.ts
@@ -9,7 +9,7 @@ const postComment = async (
   try {
     const response = await axios.post(`${SERVER}/api/v1/travels-guide/comments`, {
       userId,
-      travelId: guidePostId,
+      guidePostId,
       comment,
     });
     return response.data.success;

--- a/src/components/findGuideDetail/CommentContainer.tsx
+++ b/src/components/findGuideDetail/CommentContainer.tsx
@@ -5,14 +5,15 @@ import { css } from '@emotion/react';
 
 interface CommentContainerProps {
   commentListData: Comment[];
+  guidePostId: string;
 }
 
-const CommentContainer = ({ commentListData }: CommentContainerProps) => {
+const CommentContainer = ({ commentListData, guidePostId }: CommentContainerProps) => {
   return (
     <div css={container}>
       <h2>댓글</h2>
-      <WritingComment />
-      <CommentList commentListData={commentListData} />
+      <WritingComment guidePostId={guidePostId} />
+      <CommentList commentListData={commentListData} guidePostId={guidePostId} />
     </div>
   );
 };
@@ -20,6 +21,7 @@ const CommentContainer = ({ commentListData }: CommentContainerProps) => {
 export default CommentContainer;
 
 const container = css`
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: 10px;

--- a/src/components/findGuideDetail/CommentList.tsx
+++ b/src/components/findGuideDetail/CommentList.tsx
@@ -42,7 +42,7 @@ const CommentItem = ({ comment: data, guidePostId }: { comment: Comment; guidePo
   const handleDeleteComment = (id: string) => {
     if (user && data.commentId === id) {
       mutate(
-        { commentId: id, userId: user },
+        { commentId: id },
         {
           onSuccess: () => {
             setModalName(null);

--- a/src/components/findGuideDetail/CommentList.tsx
+++ b/src/components/findGuideDetail/CommentList.tsx
@@ -2,45 +2,108 @@ import useUserStore from '@/stores/useUserStore';
 import Profile from '../Profile';
 import { Comment } from '@/types/guideFindDataType';
 import { css } from '@emotion/react';
-import { Trash2 } from 'lucide-react';
+import { PencilLine, Trash2 } from 'lucide-react';
 import { formatDate } from '@/utils/format';
+import { useState } from 'react';
+import WritingComment from './WritingComment';
+import useDeleteComment from '@/hooks/query/useDeleteComment';
+import ConfirmModal from '../ConfirmModal';
+import useModalStore from '@/stores/useModalStore';
+import { modalId } from '@/constants/modalId';
 
 interface CommentListProps {
+  guidePostId: string;
   commentListData: Comment[];
 }
 
-const CommentList = ({ commentListData: data }: CommentListProps) => {
+const CommentList = ({ guidePostId, commentListData: data }: CommentListProps) => {
   const commentList = [...data].reverse();
   return (
     <div css={listContainer}>
       {commentList.map((comment) => (
-        <CommentItem key={comment.commentId} comment={comment} />
+        <CommentItem key={comment.commentId} comment={comment} guidePostId={guidePostId} />
       ))}
     </div>
   );
 };
 
-const CommentItem = ({ comment: data }: { comment: Comment }) => {
+const CommentItem = ({ comment: data, guidePostId }: { comment: Comment; guidePostId: string }) => {
+  const [isEdit, setIsEdit] = useState(false);
   const user = useUserStore((state) => state.user?.userId);
+  const setModalName = useModalStore((state) => state.setModalName);
+  const { mutate } = useDeleteComment(guidePostId);
+
+  const handleEditComment = (id: string) => {
+    if (data.commentId === id) {
+      setIsEdit(true);
+    }
+  };
+
+  const handleDeleteComment = (id: string) => {
+    if (user && data.commentId === id) {
+      mutate(
+        { commentId: id, userId: user },
+        {
+          onSuccess: () => {
+            setModalName(null);
+          },
+        },
+      );
+    }
+  };
+
   const isWriter = data.userId === user;
+
   return (
-    <div css={itemContainer}>
-      <div css={commentHeader}>
-        <div css={userWrapper}>
-          <Profile url={data.userProfileImage} size="37px" />
-          <div>
-            <p>{data.socialName}</p>
-            <span>{formatDate(data.updatedAt)}</span>
+    <>
+      {isEdit ? (
+        <WritingComment
+          isEdit={isEdit}
+          guidePostId={guidePostId}
+          commentId={data.commentId}
+          oldComment={data.comment}
+          onEditChange={() => setIsEdit(false)}
+        />
+      ) : (
+        <div css={itemContainer}>
+          <div css={commentHeader}>
+            <div css={userWrapper}>
+              <Profile url={data.userProfileImage} size="37px" />
+              <div>
+                <p>{data.socialName}</p>
+                <span>{formatDate(data.updatedAt)}</span>
+              </div>
+            </div>
+            {isWriter && (
+              <div css={editWrapper}>
+                <button
+                  onClick={() => handleEditComment(data.commentId)}
+                  type="button"
+                  aria-label="댓글 수정"
+                >
+                  <PencilLine stroke="#888" size="20" />
+                </button>
+                <ConfirmModal
+                  modalId={modalId.findGuide.commentDelete}
+                  message="정말 삭제하시겠습니까?"
+                  onConfirm={() => handleDeleteComment(data.commentId)}
+                  trigger={
+                    <button
+                      onClick={() => setModalName(modalId.findGuide.commentDelete)}
+                      type="button"
+                      aria-label="댓글 삭제"
+                    >
+                      <Trash2 stroke="#888" size="20" />
+                    </button>
+                  }
+                />
+              </div>
+            )}
           </div>
+          <p css={commentWrapper}>{data.comment}</p>
         </div>
-        {isWriter && (
-          <button>
-            <Trash2 stroke="#888" size="22" />
-          </button>
-        )}
-      </div>
-      <p css={commentWrapper}>{data.comment}</p>
-    </div>
+      )}
+    </>
   );
 };
 
@@ -77,6 +140,17 @@ const userWrapper = css`
     span {
       font-size: 14px;
       color: #888;
+    }
+  }
+`;
+
+const editWrapper = css`
+  display: flex;
+  gap: 12px;
+  button {
+    transition: transform 0.2s ease-in-out;
+    &:hover {
+      transform: scale(1.1);
     }
   }
 `;

--- a/src/constants/modalId.ts
+++ b/src/constants/modalId.ts
@@ -8,4 +8,7 @@ export const modalId = {
     manageUserStatusApprove: 'manage-user-status-approve',
     manageUserStatusReject: 'manage-user-status-reject',
   },
+  findGuide: {
+    commentDelete: 'comment-delete',
+  },
 } as const;

--- a/src/hooks/query/useDeleteComment.ts
+++ b/src/hooks/query/useDeleteComment.ts
@@ -3,15 +3,10 @@ import { ShowToast } from '@/components/Toast';
 import { FIND_GUIDE_DETAIL } from '@/constants/queyKey';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-interface UseDeleteCommentProps {
-  commentId: string;
-  userId: string;
-}
-
 const useDeleteComment = (guidePostId: string) => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ commentId, userId }: UseDeleteCommentProps) => deleteComment(commentId, userId),
+    mutationFn: ({ commentId }: { commentId: string }) => deleteComment(commentId),
     onSuccess: () => {
       ShowToast('댓글이 삭제되었습니다.', 'success');
       queryClient.invalidateQueries({ queryKey: [FIND_GUIDE_DETAIL, guidePostId] });

--- a/src/hooks/query/useDeleteComment.ts
+++ b/src/hooks/query/useDeleteComment.ts
@@ -1,0 +1,25 @@
+import deleteComment from '@/api/findGuideDetail/deleteComment';
+import { ShowToast } from '@/components/Toast';
+import { FIND_GUIDE_DETAIL } from '@/constants/queyKey';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+interface UseDeleteCommentProps {
+  commentId: string;
+  userId: string;
+}
+
+const useDeleteComment = (guidePostId: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ commentId, userId }: UseDeleteCommentProps) => deleteComment(commentId, userId),
+    onSuccess: () => {
+      ShowToast('댓글이 삭제되었습니다.', 'success');
+      queryClient.invalidateQueries({ queryKey: [FIND_GUIDE_DETAIL, guidePostId] });
+    },
+    onError: () => {
+      ShowToast('댓글 삭제가 실패했습니다. 잠시 후 다시 시도해주세요.', 'failed');
+    },
+  });
+};
+
+export default useDeleteComment;

--- a/src/hooks/query/usePatchComment.ts
+++ b/src/hooks/query/usePatchComment.ts
@@ -1,0 +1,27 @@
+import patchComment from '@/api/findGuideDetail/patchComment';
+import { ShowToast } from '@/components/Toast';
+import { FIND_GUIDE_DETAIL } from '@/constants/queyKey';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+interface UsePatchCommentProps {
+  commentId: string;
+  userId: string;
+  comment: string;
+}
+
+const usePatchComment = (guidePostId: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ commentId, userId, comment }: UsePatchCommentProps) =>
+      patchComment(commentId, userId, comment),
+    onSuccess: () => {
+      ShowToast('댓글이 수정되었습니다.', 'success');
+      queryClient.invalidateQueries({ queryKey: [FIND_GUIDE_DETAIL, guidePostId] });
+    },
+    onError: () => {
+      ShowToast('댓글 수정에 실패했습니다. 잠시 후 다시 시도해주세요.', 'failed');
+    },
+  });
+};
+
+export default usePatchComment;

--- a/src/pages/FindGuideDetail.tsx
+++ b/src/pages/FindGuideDetail.tsx
@@ -21,7 +21,9 @@ const FindGuideDetail = () => {
         <Title title={title} createdAt={createdAt} />
         {thumbnail && <Thumbnail thumbnail={thumbnail} />}
         <Introduction content={content} />
-        {commentList && <CommentContainer commentListData={commentList} />}
+        {commentList && guidePostId && (
+          <CommentContainer commentListData={commentList} guidePostId={guidePostId} />
+        )}
       </div>
       <div css={sideWrapper}>{team && <SideTravelTeam teams={team} />}</div>
     </div>


### PR DESCRIPTION
## 📋 작업 세부 사항

댓글 수정, 삭제 기능 추가

## 🔧 변경 사항 요약

- 댓글 수정, 삭제의 api와 훅 추가
- 일부 props 수정
- writingComment 활용하여 댓글 수정기능 추가
- 댓글 삭제 기능 추가 (+재확인 모달)
- 로그인하지 않는 유저일시 댓글추가 컴포넌트 없음 -> 안내문구 추가

<!-- ## 📸 스크린샷 (선택 사항) -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 가이드 게시물의 댓글 관리 기능 추가
	- 댓글 수정 및 삭제 기능 구현
	- 댓글 작성 기능 개선 (가이드 게시물 ID 사용)

- **버그 수정**
	- 댓글 관련 API 호출 시 안정성 개선
	- 사용자 인증 및 권한 검증 로직 강화

- **사용자 경험 개선**
	- 댓글 편집 모드 추가
	- 댓글 삭제 시 확인 모달 제공
	- 댓글 작성자에게만 수정/삭제 버튼 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->