### PR TITLE
[Fix] 댓글 api 추가 및 수정, 페이지네이션 기능 추가

### DIFF
--- a/src/api/findGuideDetail/getCommentList.ts
+++ b/src/api/findGuideDetail/getCommentList.ts
@@ -1,0 +1,17 @@
+import { COMMENT_COUNT_PER_PAGE } from '@/constants/countPerPage';
+import { SERVER } from '@/constants/url';
+import { CommentData } from '@/types/guideFindDataType';
+import axios from 'axios';
+
+const getCommentList = async (guidePostId: string, page: number): Promise<CommentData> => {
+  try {
+    const response = await axios.get(
+      `${SERVER}/api/v1/travels-guide/comments/${guidePostId}?page=${page}&size=${COMMENT_COUNT_PER_PAGE}`,
+    );
+    return response.data.data;
+  } catch (err) {
+    throw new Error(err instanceof Error ? err.message : '댓글 목록 가져오기 실패');
+  }
+};
+
+export default getCommentList;

--- a/src/components/findGuideDetail/CommentContainer.tsx
+++ b/src/components/findGuideDetail/CommentContainer.tsx
@@ -1,19 +1,44 @@
+import Pagination from '@mui/material/Pagination';
 import CommentList from './CommentList';
 import WritingComment from './WritingComment';
-import { Comment } from '@/types/guideFindDataType';
 import { css } from '@emotion/react';
+import useGetCommentList from '@/hooks/query/useGetCommentList';
+import { useState } from 'react';
 
 interface CommentContainerProps {
-  commentListData: Comment[];
   guidePostId: string;
 }
 
-const CommentContainer = ({ commentListData, guidePostId }: CommentContainerProps) => {
+const CommentContainer = ({ guidePostId }: CommentContainerProps) => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const { data: commentData, refetch } = useGetCommentList(guidePostId as string, currentPage);
+
+  const handlePage = async (_: React.ChangeEvent<unknown>, page: number) => {
+    await setCurrentPage(page);
+    refetch();
+  };
+
   return (
     <div css={container}>
       <h2>댓글</h2>
       <WritingComment guidePostId={guidePostId} />
-      <CommentList commentListData={commentListData} guidePostId={guidePostId} />
+      <div css={listWrapper}>
+        {commentData?.pageInfo && commentData?.commentList ? (
+          <>
+            <CommentList commentListData={commentData.commentList} guidePostId={guidePostId} />
+            <Pagination
+              count={commentData.pageInfo.totalPages || 0}
+              page={currentPage}
+              onChange={handlePage}
+              color="primary"
+              showFirstButton
+              showLastButton
+            />
+          </>
+        ) : (
+          <p css={noList}>등록된 댓글이 없습니다.</p>
+        )}
+      </div>
     </div>
   );
 };
@@ -29,4 +54,18 @@ const container = css`
     font-size: 18px;
     font-weight: 600;
   }
+`;
+
+const listWrapper = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+`;
+
+const noList = css`
+  margin: 26px auto;
+  color: #888;
+  font-size: 16px;
+  font-weight: 600;
 `;

--- a/src/components/findGuideDetail/CommentList.tsx
+++ b/src/components/findGuideDetail/CommentList.tsx
@@ -4,7 +4,7 @@ import { Comment } from '@/types/guideFindDataType';
 import { css } from '@emotion/react';
 import { PencilLine, Trash2 } from 'lucide-react';
 import { formatDate } from '@/utils/format';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import WritingComment from './WritingComment';
 import useDeleteComment from '@/hooks/query/useDeleteComment';
 import ConfirmModal from '../ConfirmModal';
@@ -17,10 +17,9 @@ interface CommentListProps {
 }
 
 const CommentList = ({ guidePostId, commentListData: data }: CommentListProps) => {
-  const commentList = [...data].reverse();
   return (
     <div css={listContainer}>
-      {commentList.map((comment) => (
+      {data.map((comment) => (
         <CommentItem key={comment.commentId} comment={comment} guidePostId={guidePostId} />
       ))}
     </div>
@@ -29,6 +28,7 @@ const CommentList = ({ guidePostId, commentListData: data }: CommentListProps) =
 
 const CommentItem = ({ comment: data, guidePostId }: { comment: Comment; guidePostId: string }) => {
   const [isEdit, setIsEdit] = useState(false);
+  const deleteButtonRef = useRef<HTMLButtonElement>(null);
   const user = useUserStore((state) => state.user?.userId);
   const setModalName = useModalStore((state) => state.setModalName);
   const { mutate } = useDeleteComment(guidePostId);
@@ -84,14 +84,17 @@ const CommentItem = ({ comment: data, guidePostId }: { comment: Comment; guidePo
                   <PencilLine stroke="#888" size="20" />
                 </button>
                 <ConfirmModal
-                  modalId={modalId.findGuide.commentDelete}
+                  modalId={`${modalId.findGuide.commentDelete}-${data.commentId}`}
                   message="정말 삭제하시겠습니까?"
                   onConfirm={() => handleDeleteComment(data.commentId)}
                   trigger={
                     <button
-                      onClick={() => setModalName(modalId.findGuide.commentDelete)}
+                      onClick={() =>
+                        setModalName(`${modalId.findGuide.commentDelete}-${data.commentId}`)
+                      }
                       type="button"
                       aria-label="댓글 삭제"
+                      ref={deleteButtonRef}
                     >
                       <Trash2 stroke="#888" size="20" />
                     </button>

--- a/src/constants/countPerPage.ts
+++ b/src/constants/countPerPage.ts
@@ -1,1 +1,2 @@
 export const MANAGE_COUNT_PER_PAGE = 6;
+export const COMMENT_COUNT_PER_PAGE = 4;

--- a/src/constants/queyKey.ts
+++ b/src/constants/queyKey.ts
@@ -7,3 +7,4 @@ export const MY_JOINED_TRAVEL = 'my-joined-travel';
 export const HOME_TRAVEL_LIST = 'home-travel-list';
 export const HOME_GUIDE_LIST = 'home-guide-list';
 export const FIND_GUIDE_DETAIL = 'find-guide-detail';
+export const COMMENT_LIST = 'comment-list';

--- a/src/hooks/query/useDeleteComment.ts
+++ b/src/hooks/query/useDeleteComment.ts
@@ -1,6 +1,6 @@
 import deleteComment from '@/api/findGuideDetail/deleteComment';
 import { ShowToast } from '@/components/Toast';
-import { FIND_GUIDE_DETAIL } from '@/constants/queyKey';
+import { COMMENT_LIST } from '@/constants/queyKey';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 const useDeleteComment = (guidePostId: string) => {
@@ -9,7 +9,7 @@ const useDeleteComment = (guidePostId: string) => {
     mutationFn: ({ commentId }: { commentId: string }) => deleteComment(commentId),
     onSuccess: () => {
       ShowToast('댓글이 삭제되었습니다.', 'success');
-      queryClient.invalidateQueries({ queryKey: [FIND_GUIDE_DETAIL, guidePostId] });
+      queryClient.invalidateQueries({ queryKey: [COMMENT_LIST, guidePostId] });
     },
     onError: () => {
       ShowToast('댓글 삭제가 실패했습니다. 잠시 후 다시 시도해주세요.', 'failed');

--- a/src/hooks/query/useGetCommentList.ts
+++ b/src/hooks/query/useGetCommentList.ts
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 
 const useGetCommentList = (guidePostId: string, page: number) => {
   return useQuery({
-    queryKey: [COMMENT_LIST, guidePostId],
+    queryKey: [COMMENT_LIST, guidePostId, page],
     queryFn: () => getCommentList(guidePostId, page),
   });
 };

--- a/src/hooks/query/useGetCommentList.ts
+++ b/src/hooks/query/useGetCommentList.ts
@@ -1,0 +1,12 @@
+import getCommentList from '@/api/findGuideDetail/getCommentList';
+import { COMMENT_LIST } from '@/constants/queyKey';
+import { useQuery } from '@tanstack/react-query';
+
+const useGetCommentList = (guidePostId: string, page: number) => {
+  return useQuery({
+    queryKey: [COMMENT_LIST, guidePostId],
+    queryFn: () => getCommentList(guidePostId, page),
+  });
+};
+
+export default useGetCommentList;

--- a/src/hooks/query/usePatchComment.ts
+++ b/src/hooks/query/usePatchComment.ts
@@ -1,6 +1,7 @@
 import patchComment from '@/api/findGuideDetail/patchComment';
 import { ShowToast } from '@/components/Toast';
-import { FIND_GUIDE_DETAIL } from '@/constants/queyKey';
+import { COMMENT_LIST } from '@/constants/queyKey';
+
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 interface UsePatchCommentProps {
@@ -16,7 +17,7 @@ const usePatchComment = (guidePostId: string) => {
       patchComment(commentId, userId, comment),
     onSuccess: () => {
       ShowToast('댓글이 수정되었습니다.', 'success');
-      queryClient.invalidateQueries({ queryKey: [FIND_GUIDE_DETAIL, guidePostId] });
+      queryClient.invalidateQueries({ queryKey: [COMMENT_LIST, guidePostId] });
     },
     onError: () => {
       ShowToast('댓글 수정에 실패했습니다. 잠시 후 다시 시도해주세요.', 'failed');

--- a/src/hooks/query/usePostComment.ts
+++ b/src/hooks/query/usePostComment.ts
@@ -1,6 +1,6 @@
 import postComment from '@/api/findGuideDetail/postComment';
 import { ShowToast } from '@/components/Toast';
-import { FIND_GUIDE_DETAIL } from '@/constants/queyKey';
+import { COMMENT_LIST } from '@/constants/queyKey';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 interface UsePostCommentProps {
@@ -16,7 +16,7 @@ const usePostComment = () => {
       postComment(userId, guidePostId, comment),
     onSuccess: (_, { guidePostId }) => {
       ShowToast('댓글이 등록되었습니다.', 'success');
-      queryClient.invalidateQueries({ queryKey: [FIND_GUIDE_DETAIL, guidePostId] });
+      queryClient.invalidateQueries({ queryKey: [COMMENT_LIST, guidePostId] });
     },
     onError: () => {
       ShowToast('댓글 등록에 실패했습니다. 잠시 후 다시 시도해주세요.', 'failed');

--- a/src/pages/FindGuideDetail.tsx
+++ b/src/pages/FindGuideDetail.tsx
@@ -13,7 +13,7 @@ const FindGuideDetail = () => {
 
   if (!findGuideData) return null;
 
-  const { title, createdAt, thumbnail, content, commentList, team } = findGuideData;
+  const { title, createdAt, thumbnail, content, team } = findGuideData;
 
   return (
     <div css={container}>
@@ -21,9 +21,7 @@ const FindGuideDetail = () => {
         <Title title={title} createdAt={createdAt} />
         {thumbnail && <Thumbnail thumbnail={thumbnail} />}
         <Introduction content={content} />
-        {commentList && guidePostId && (
-          <CommentContainer commentListData={commentList} guidePostId={guidePostId} />
-        )}
+        {guidePostId && <CommentContainer guidePostId={guidePostId} />}
       </div>
       <div css={sideWrapper}>{team && <SideTravelTeam teams={team} />}</div>
     </div>

--- a/src/types/guideFindDataType.ts
+++ b/src/types/guideFindDataType.ts
@@ -31,6 +31,17 @@ export interface Comment {
   comment: string;
 }
 
+export interface PageInfo {
+  currentPage: number;
+  totalPages: number;
+  totalComments: number;
+}
+
+export interface CommentData {
+  commentList: Comment[] | null;
+  pageInfo: PageInfo;
+}
+
 export interface FindGuideDetailData {
   author: Author;
   title: string;
@@ -38,5 +49,4 @@ export interface FindGuideDetailData {
   thumbnail: string | null;
   team: DetailTeam[] | null;
   createdAt: string;
-  commentList: Comment[] | null;
 }


### PR DESCRIPTION
## 📋 작업 세부 사항

댓글 api 추가 및 수정, 페이지네이션 기능 추가

## 🔧 변경 사항 요약

- 분리된 댓글 api 추가 후 기존 타입 수정, 훅 쿼리키 수정
- 페이지네이션 기능 추가
- 삭제시 재확인모달에서 commentId값이 제대로 넘겨지지 않는 오류 발생 -> 모달Id 명확히하고 버튼ref적용

<!-- ## 📸 스크린샷 (선택 사항) -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

- **새로운 기능**
	- 여행 가이드 게시물의 댓글 페이지네이션 기능 추가
	- 댓글 목록을 동적으로 불러오는 기능 구현

- **개선 사항**
	- 댓글 관리 및 표시 방식 최적화
	- 댓글 삭제 및 모달 상호작용 개선

- **기술적 변경**
	- 댓글 관련 데이터 구조 및 쿼리 관리 방식 리팩토링
	- 페이지네이션을 위한 새로운 상수 및 인터페이스 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->