### PR TITLE
[Fix]사이드바 및 내여행-tab관련 수정

### DIFF
--- a/src/components/myPage/MyPageSideMenu.tsx
+++ b/src/components/myPage/MyPageSideMenu.tsx
@@ -1,33 +1,40 @@
 import { theme } from '@/styles/theme';
 import { css } from '@emotion/react';
-import { NavLink } from 'react-router-dom';
+import { NavLink, useLocation } from 'react-router-dom';
 
-const sideMeunItems = [
+const sideMenuItems = [
   {
     name: '계정',
-    to: 'my-account',
+    activePaths: ['my-account'],
   },
   {
     name: '내 여행',
-    to: 'my-travel-list',
+    activePaths: ['my-travel-list', 'my-created-travel'],
   },
   {
     name: '작성 후기',
-    to: 'my-reviews',
+    activePaths: ['my-reviews'],
   },
   {
     name: '가이드 찾아요',
-    to: 'my-find-guide',
+    activePaths: ['my-find-guide'],
   },
 ];
 
 const MyPageSideMenu = () => {
+  const location = useLocation();
+
   return (
     <nav css={sideMenuStyle}>
       <ul>
-        {sideMeunItems.map((item, index) => (
+        {sideMenuItems.map((item, index) => (
           <li key={index}>
-            <NavLink to={item.to} className={({ isActive }) => (isActive ? 'active' : '')}>
+            <NavLink
+              to={item.activePaths[0]}
+              className={() =>
+                item.activePaths.some((path) => location.pathname.includes(path)) ? 'active' : ''
+              }
+            >
               {item.name}
             </NavLink>
           </li>

--- a/src/components/myTravel/MyTravelTab.tsx
+++ b/src/components/myTravel/MyTravelTab.tsx
@@ -1,10 +1,19 @@
 import { useTabStore } from '@/stores/useTabStore';
 import styled from '@emotion/styled';
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 const MyTravelTab = () => {
   const { selectedTab, setSelectedTab } = useTabStore();
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (location.pathname === '/my-page/my-travel-list') {
+      setSelectedTab('참여한 여행');
+    } else if (location.pathname === '/my-page/my-created-travel') {
+      setSelectedTab('내가 만든 여행');
+    }
+  }, [setSelectedTab]);
 
   const handleTabClick = (tab: '참여한 여행' | '내가 만든 여행') => {
     setSelectedTab(tab);

--- a/src/components/myTravel/MyTravelTab.tsx
+++ b/src/components/myTravel/MyTravelTab.tsx
@@ -1,11 +1,12 @@
 import { useTabStore } from '@/stores/useTabStore';
 import styled from '@emotion/styled';
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 
 const MyTravelTab = () => {
   const { selectedTab, setSelectedTab } = useTabStore();
   const navigate = useNavigate();
+  const location = useLocation();
 
   useEffect(() => {
     if (location.pathname === '/my-page/my-travel-list') {
@@ -13,7 +14,7 @@ const MyTravelTab = () => {
     } else if (location.pathname === '/my-page/my-created-travel') {
       setSelectedTab('내가 만든 여행');
     }
-  }, [setSelectedTab]);
+  }, [location.pathname, setSelectedTab]);
 
   const handleTabClick = (tab: '참여한 여행' | '내가 만든 여행') => {
     setSelectedTab(tab);

--- a/src/hooks/query/useUpdateAccountNumber.ts
+++ b/src/hooks/query/useUpdateAccountNumber.ts
@@ -29,6 +29,7 @@ const useUpdateAccountNumber = () => {
         };
         return updatedUser;
       });
+
       ShowToast('계좌정보가 수정되었습니다.', 'success');
     },
     onError: () => {

--- a/src/pages/MyAccount.tsx
+++ b/src/pages/MyAccount.tsx
@@ -13,7 +13,7 @@ import { Camera } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import Toast, { ShowToast } from '@/components/Toast';
+import { ShowToast } from '@/components/Toast';
 import useUpdateProfile from '@/hooks/query/useUpdateProfile';
 
 const MyAccount = () => {
@@ -201,7 +201,6 @@ const MyAccount = () => {
         )}
       </EditProfile>
       <Logout>{user && <LogoutBtn onClick={logout}>로그아웃</LogoutBtn>}</Logout>
-      <Toast />
     </MyAccountWrap>
   );
 };


### PR DESCRIPTION
## 📋 작업 세부 사항

계좌 수정에서 toast가 작동하지 않던 문제 수정
내여행에서 내가만든 여행과, 내가 참여한 여행 두가지 탭 모두에서 사이드바 내여행 백그라운드컬러 활성화
내가 만든 여행 탭을 누른상태에서 페이지 이동 하고 돌아와도 활성화된 탭이 초기화 되지 않던 문제 수정
## 🔧 변경 사항 요약

<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- ## 📸 스크린샷 (선택 사항) -->
![image](https://github.com/user-attachments/assets/89c1bb1a-04f0-4db4-89b6-1142b7e0f6d6)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 사이드 메뉴의 활성 상태 결정 로직 개선
	- 여행 탭 선택 기능 자동화
	- 계좌 정보 업데이트 시 성공 알림 추가

- **스타일**
	- 마이페이지 알림 컴포넌트 렌더링 방식 변경

이번 릴리즈에서는 사용자 경험을 향상시키는 여러 개선 사항을 포함하고 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->