### PR TITLE
[Feat]내가 만든여행, 내가 참여한 여행 무한스크롤 적용

### DIFF
--- a/src/api/myCreatedTravel/getMycreatedTravel.ts
+++ b/src/api/myCreatedTravel/getMycreatedTravel.ts
@@ -1,12 +1,53 @@
 import { SERVER } from '@/constants/url';
+import { myCreatedTravel } from '@/types/myCreatedTravelType';
 import axios from 'axios';
 
-const getMyCreatedTravel = async (userId: string) => {
+interface IGetMyCreatedTravel {
+  userId: string;
+  page: number;
+  size: number;
+}
+
+interface IMyCreatedPageInfo {
+  totalElements: number;
+  totalPages: number;
+  currentPage: number;
+  pageSize: number;
+  hasNext: boolean;
+}
+
+interface IGetMyCreatedTravelRes {
+  success: boolean;
+  data: {
+    travels: myCreatedTravel[];
+    pageInfo: IMyCreatedPageInfo;
+  };
+}
+
+export interface IGetMyCreatedTravelReturn {
+  travelDatas: myCreatedTravel[];
+  nextCursor: number | null;
+  currentPage: number;
+}
+
+const getMyCreatedTravel = async ({ userId, page, size }: IGetMyCreatedTravel) => {
   try {
-    const response = await axios.get(
-      `${SERVER}/api/v1/travels/my-created-travels?userId=${userId}`,
+    const params = new URLSearchParams({
+      userId,
+      page: page.toString(),
+      size: size.toString(),
+    });
+    const response = await axios.get<IGetMyCreatedTravelRes>(
+      `${SERVER}/api/v1/travels/my-created-travels?${params.toString()}`,
     );
-    return response.data.data;
+    const { currentPage, hasNext } = response.data.data.pageInfo;
+    const createdTravelDatas = response.data.data.travels;
+    const nextCursor = hasNext ? currentPage + 1 : null;
+    return {
+      createdTravelDatas,
+      nextCursor,
+      currentPage,
+    };
   } catch (err) {
     throw new Error(err instanceof Error ? err.message : '내가만든 여행 데이터 가져오기 실패');
   }

--- a/src/api/myJoinedTravel/getMyJoinedTravel.ts
+++ b/src/api/myJoinedTravel/getMyJoinedTravel.ts
@@ -1,10 +1,53 @@
 import { SERVER } from '@/constants/url';
+import { myJoinedTravel } from '@/types/myJoinedTravel';
 import axios from 'axios';
 
-const getMyJoinedTravel = async (userId: string) => {
+interface IGetMyJoinedTravel {
+  userId: string;
+  page: number;
+  size: number;
+}
+
+interface IMyJoinedPageInfo {
+  totalElements: number;
+  totalPages: number;
+  currentPage: number;
+  pageSize: number;
+  hasNext: boolean;
+}
+
+interface IGETMyJoinedTravelRes {
+  success: boolean;
+  data: {
+    travels: myJoinedTravel[];
+    pageInfo: IMyJoinedPageInfo;
+  };
+}
+
+export interface IGetMyJoinedTravelReturn {
+  travelDatas: myJoinedTravel[];
+  nextCursor: number | null;
+  currentPage: number;
+}
+
+const getMyJoinedTravel = async ({ userId, page, size }: IGetMyJoinedTravel) => {
   try {
-    const response = await axios.get(`${SERVER}/api/v1/travels/my-travels?userId=${userId}`);
-    return response.data.data;
+    const params = new URLSearchParams({
+      userId,
+      page: page.toString(),
+      size: size.toString(),
+    });
+    const response = await axios.get<IGETMyJoinedTravelRes>(
+      `${SERVER}/api/v1/travels/my-travels?${params.toString()}`,
+    );
+    const { currentPage, hasNext } = response.data.data.pageInfo;
+    const travelDatas = response.data.data.travels;
+    const nextCursor = hasNext ? currentPage + 1 : null;
+    return {
+      travelDatas,
+      nextCursor,
+      currentPage,
+    };
   } catch (err) {
     throw new Error(err instanceof Error ? err.message : '내가참여한 여행 데이터 가져오기 실패');
   }

--- a/src/components/myTravel/MyJoinedContent.tsx
+++ b/src/components/myTravel/MyJoinedContent.tsx
@@ -11,10 +11,11 @@ import { useQueryClient } from '@tanstack/react-query';
 import { IGetMyJoinedTravelReturn } from '@/api/myJoinedTravel/getMyJoinedTravel';
 import { useCallback } from 'react';
 import scrollToTop from '@/utils/scrollToTop';
+import { MY_JOINED_TRAVEL } from '@/constants/queryKey';
 
 interface InfiniteQueryData<TPageData> {
   pages: TPageData[];
-  pageParams: unknown[];
+  pageParams: number[];
 }
 
 type MyJoinedInfiniteQueryData = InfiniteQueryData<IGetMyJoinedTravelReturn>;
@@ -42,7 +43,7 @@ const MyJoinedContent = () => {
 
   const resetQueryData = useCallback(
     (key: string) => {
-      queryClient.setQueryData<MyJoinedInfiniteQueryData>(['my-joined-travel', key], (data) => {
+      queryClient.setQueryData<MyJoinedInfiniteQueryData>([MY_JOINED_TRAVEL, key], (data) => {
         if (data) {
           return {
             pages: data.pages.slice(0, 1),

--- a/src/components/myTravel/MyJoinedContent.tsx
+++ b/src/components/myTravel/MyJoinedContent.tsx
@@ -9,7 +9,7 @@ import { Link } from 'react-router-dom';
 import { useInView } from 'react-intersection-observer';
 import { useQueryClient } from '@tanstack/react-query';
 import { IGetMyJoinedTravelReturn } from '@/api/myJoinedTravel/getMyJoinedTravel';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import scrollToTop from '@/utils/scrollToTop';
 import { MY_JOINED_TRAVEL } from '@/constants/queryKey';
 
@@ -38,7 +38,6 @@ const formatDateRange = (startDate: string, endDate: string) => {
 
 const MyJoinedContent = () => {
   const { user } = useUserStore((state) => state);
-  // const { data: myJoinedTravelData } = useGetMyJoinedTravel(user?.userId as string);
   const queryClient = useQueryClient();
 
   const resetQueryData = useCallback(
@@ -58,9 +57,11 @@ const MyJoinedContent = () => {
 
   console.log(resetQueryData);
 
-  // useEffect(() => {
-  //   resetQueryData(userId);
-  // }, [userId, resetQueryData]);
+  useEffect(() => {
+    if (user?.userId) {
+      resetQueryData(user.userId);
+    }
+  }, [user?.userId, resetQueryData]);
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useGetMyJoinedTravel({
     userId: user?.userId || '',

--- a/src/components/myTravel/MyJoinedContent.tsx
+++ b/src/components/myTravel/MyJoinedContent.tsx
@@ -12,6 +12,7 @@ import { IGetMyJoinedTravelReturn } from '@/api/myJoinedTravel/getMyJoinedTravel
 import { useCallback, useEffect } from 'react';
 import scrollToTop from '@/utils/scrollToTop';
 import { MY_JOINED_TRAVEL } from '@/constants/queryKey';
+import ReviewWriteModal from '@/components/myReview/ReviewWriteModal';
 
 interface InfiniteQueryData<TPageData> {
   pages: TPageData[];
@@ -19,7 +20,6 @@ interface InfiniteQueryData<TPageData> {
 }
 
 type MyJoinedInfiniteQueryData = InfiniteQueryData<IGetMyJoinedTravelReturn>;
-import ReviewWriteModal from '@/components/myReview/ReviewWriteModal';
 
 // 남은 일수 계산 함수
 const calculateDaysRemaining = (endDateString: string) => {

--- a/src/components/myTravel/MyJoinedContent.tsx
+++ b/src/components/myTravel/MyJoinedContent.tsx
@@ -55,8 +55,6 @@ const MyJoinedContent = () => {
     [queryClient],
   );
 
-  console.log(resetQueryData);
-
   useEffect(() => {
     if (user?.userId) {
       resetQueryData(user.userId);

--- a/src/hooks/query/useGetMyCreatedTravel.ts
+++ b/src/hooks/query/useGetMyCreatedTravel.ts
@@ -1,11 +1,20 @@
 import getMyCreatedTravel from '@/api/myCreatedTravel/getMycreatedTravel';
 import { MY_CREATED_TRAVEL } from '@/constants/queryKey';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 
-const useGetMyCreatedTravel = (userId: string) => {
-  return useQuery({
+interface IUseGetTravelList {
+  userId: string;
+}
+
+const useGetMyCreatedTravel = ({ userId }: IUseGetTravelList) => {
+  const pageSize = 6;
+  return useInfiniteQuery({
     queryKey: [MY_CREATED_TRAVEL, userId],
-    queryFn: () => getMyCreatedTravel(userId),
+    queryFn: ({ pageParam }) => getMyCreatedTravel({ userId, page: pageParam, size: pageSize }),
+    getNextPageParam: (lastPage) => {
+      return lastPage.nextCursor;
+    },
+    initialPageParam: 1,
   });
 };
 

--- a/src/hooks/query/useGetMyJoinedTravel.ts
+++ b/src/hooks/query/useGetMyJoinedTravel.ts
@@ -1,11 +1,20 @@
 import getMyJoinedTravel from '@/api/myJoinedTravel/getMyJoinedTravel';
 import { MY_JOINED_TRAVEL } from '@/constants/queryKey';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 
-const useGetMyJoinedTravel = (userId: string) => {
-  return useQuery({
+interface IUseGetTravelList {
+  userId: string;
+}
+
+const useGetMyJoinedTravel = ({ userId }: IUseGetTravelList) => {
+  const pageSize = 6;
+  return useInfiniteQuery({
     queryKey: [MY_JOINED_TRAVEL, userId],
-    queryFn: () => getMyJoinedTravel(userId),
+    queryFn: ({ pageParam }) => getMyJoinedTravel({ userId, page: pageParam, size: pageSize }),
+    getNextPageParam: (lastPage) => {
+      return lastPage.nextCursor;
+    },
+    initialPageParam: 1,
   });
 };
 

--- a/src/pages/TravelList.tsx
+++ b/src/pages/TravelList.tsx
@@ -11,10 +11,11 @@ import useGetTravelList from '@/hooks/query/useGetTravelList';
 import { useCallback, useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { IGetTravelListReturn } from '@/api/travelList/getTravelList';
+import { TRAVEL_LIST } from '@/constants/queryKey';
 
 interface InfiniteQueryData<TPageData> {
   pages: TPageData[];
-  pageParams: unknown[];
+  pageParams: number[];
 }
 type TravelListInfiniteQueryData = InfiniteQueryData<IGetTravelListReturn>;
 
@@ -27,7 +28,7 @@ const TravelList = () => {
 
   const resetQueryData = useCallback(
     (key: string) => {
-      queryClient.setQueryData<TravelListInfiniteQueryData>(['travelList', key], (data) => {
+      queryClient.setQueryData<TravelListInfiniteQueryData>([TRAVEL_LIST, key], (data) => {
         if (data) {
           return {
             pages: data.pages.slice(0, 1),


### PR DESCRIPTION
## 📋 작업 세부 사항

내가 만든여행, 내가 참여한 여행 무한스크롤 적용

## 🔧 변경 사항 요약

내가 만든여행, 내가 참여한 여행 무한스크롤 적용
<!-- ## 📸 스크린샷 (선택 사항) -->

![image](https://github.com/user-attachments/assets/13f9bb93-5542-4424-b9aa-ab4480a3bcc6)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 여행 목록 페이지에 무한 스크롤 기능 추가
	- 내가 만든 여행과 참여한 여행 목록의 페이지네이션 구현
	- 사용자 여행 데이터 로딩 및 관리 방식 개선

- **버그 수정**
	- 데이터 로딩 및 상태 관리의 안정성 향상
	- 쿼리 데이터 처리 로직 최적화

- **성능 개선**
	- 데이터 페치 및 렌더링 효율성 증대
	- 스크롤 시 동적 데이터 로딩 메커니즘 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->