### PR TITLE
[Fix] 여행 글쓰기에서 이미지 업로드 오류/ 이미지 리랜더 오류

### DIFF
--- a/src/api/addTravel/getImageUrl.ts
+++ b/src/api/addTravel/getImageUrl.ts
@@ -1,0 +1,21 @@
+import { SERVER } from '@/constants/url';
+
+const getImageUrl = async (file: File): Promise<string> => {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const response = await fetch(`${SERVER}/api/images/upload/single`, {
+    method: 'POST',
+    body: formData,
+  });
+
+  const { success, data } = await response.json();
+
+  if (!success) {
+    throw new Error('Failed to upload image');
+  }
+
+  return data.imageUrl;
+};
+
+export default getImageUrl;

--- a/src/api/addTravel/getImageUrl.ts
+++ b/src/api/addTravel/getImageUrl.ts
@@ -1,21 +1,21 @@
 import { SERVER } from '@/constants/url';
+import axios from 'axios';
 
 const getImageUrl = async (file: File): Promise<string> => {
   const formData = new FormData();
   formData.append('file', file);
 
-  const response = await fetch(`${SERVER}/api/images/upload/single`, {
-    method: 'POST',
-    body: formData,
+  const { data } = await axios.post(`${SERVER}/api/images/upload/single`, formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
   });
 
-  const { success, data } = await response.json();
-
-  if (!success) {
+  if (!data.success) {
     throw new Error('Failed to upload image');
   }
 
-  return data.imageUrl;
+  return data.data.imageUrl;
 };
 
 export default getImageUrl;

--- a/src/components/addTravel/Introduction.tsx
+++ b/src/components/addTravel/Introduction.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import GrayBack from '@/components/GrayBack';
+import { ShowToast } from '@/components/Toast';
 import useGetImageUrl from '@/hooks/query/useGetImageUrl';
 import useAddTravelStore from '@/stores/useAddTravelStore';
 import useFieldStore from '@/stores/useFieldStore';
@@ -53,7 +54,11 @@ const Introduction = ({ title = '상품 소개' }: IntroductionProps) => {
       return;
     }
 
-    setImgLimit(imgUrls.length > 4);
+    if (imgUrls.length > 4) {
+      setImgLimit(true);
+      ShowToast('이미지는 최대 4개만 사용 가능합니다.', 'failed');
+      return;
+    }
 
     for (const imgSrc of imgUrls) {
       if (uploadedImages.includes(imgSrc)) continue;

--- a/src/components/addTravel/Thumbnail.tsx
+++ b/src/components/addTravel/Thumbnail.tsx
@@ -2,7 +2,7 @@ import GrayBack from '@/components/GrayBack';
 import useImageStore from '@/stores/useImageStore';
 import { css } from '@emotion/react';
 import { ImagePlus } from 'lucide-react';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, memo, useCallback, useState } from 'react';
 
 type ThumbnailType = 'thumbnail' | 'meetingSpace';
 
@@ -10,7 +10,7 @@ interface ThumbnailProps {
   type: ThumbnailType;
 }
 
-const Thumbnail = ({ type }: ThumbnailProps) => {
+const Thumbnail = memo(({ type }: ThumbnailProps) => {
   const [errMessage, setErrMessage] = useState('');
   const { thumbnail, meetingSpace } = useImageStore((state) => state.images);
   const { setThumbnail, setMeetingSpace } = useImageStore((state) => state.actions);
@@ -46,9 +46,9 @@ const Thumbnail = ({ type }: ThumbnailProps) => {
     }
   };
 
-  const getPreviewUrl = (file: File | null) => {
+  const getPreviewUrl = useCallback((file: File | null) => {
     return file ? URL.createObjectURL(file) : '';
-  };
+  }, []);
 
   const DATA_OF_TYPE = {
     thumbnail: {
@@ -74,7 +74,7 @@ const Thumbnail = ({ type }: ThumbnailProps) => {
       <p css={{ fontSize: '14px', color: '#ff2020' }}>{errMessage}</p>
     </>
   );
-};
+});
 
 export default Thumbnail;
 

--- a/src/hooks/query/useGetImageUrl.ts
+++ b/src/hooks/query/useGetImageUrl.ts
@@ -1,0 +1,22 @@
+import { useMutation } from '@tanstack/react-query';
+import { ShowToast } from '@/components/Toast';
+import getImageUrl from '@/api/addTravel/getImageUrl';
+
+export interface UseImageUploadProps {
+  file: File;
+}
+
+const useGetImageUrl = () => {
+  return useMutation<string, Error, UseImageUploadProps>({
+    mutationFn: ({ file }) => getImageUrl(file),
+    onError: () => {
+      ShowToast('이미지 업로드 중 오류가 발생하였습니다. 다시 시도해주세요', 'failed');
+    },
+    onSuccess: (imageUrl) => {
+      ShowToast('이미지 업로드에 성공했습니다.', 'success');
+      return imageUrl;
+    },
+  });
+};
+
+export default useGetImageUrl;

--- a/src/utils/prepareImageUpload.ts
+++ b/src/utils/prepareImageUpload.ts
@@ -1,25 +1,18 @@
 import { ImageStore } from '@/stores/useImageStore';
 
-const formData = new FormData();
-
-const addImageToFormData = (type: string, file: File) => {
-  if (!file) return;
-  formData.append(type, file);
-};
-
 const prepareImageUpload = (images: ImageStore) => {
+  const formData = new FormData();
   if (images.thumbnail) {
-    addImageToFormData('thumbnail', images.thumbnail);
+    formData.append('thumbnail', images.thumbnail);
   }
   if (images.meetingSpace) {
-    addImageToFormData('meetingSpace', images.meetingSpace);
+    formData.append('meetingSpace', images.meetingSpace);
   }
   if (images.introSrcs.length > 0) {
     images.introSrcs.forEach((src) => {
-      addImageToFormData('introSrcs', src);
+      formData.append('introSrcs', src);
     });
   }
-
   return formData;
 };
 


### PR DESCRIPTION
- **fix: image reRender #214**
- **fix: 이미지 업로드 오류 해결 #214**
 - 여행 글에 이미지를 넣으면 즉시 API를 요청해서 이미지를 업로드하게 수정

PR 검토 필요
1. 이미지 업로드 오류 해결(이미지 업로드 api 호출시 오류 수정), .
2. 여행 글 작성시 이미지가 계속해서 깜빡이는 현상 해결

그러나 아직 이미지를 포함해서 여행 소개글 작성시 오류 발생
여행 소개 글에 이미지가 포함되면 너무 긴 텍스트가 되버리기 때문에 오류가 걸리는 걸로 추정됨.
이미지 업로드 api 호출과는 별개의 문제로 판단됨.

## 📋 작업 세부 사항

<!-- 변경 사항이나 추가된 기능에 대해 자세히 설명해 주세요. -->

## 🔧 변경 사항 요약

<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- ## 📸 스크린샷 (선택 사항) -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **성능 최적화**
	- 썸네일 컴포넌트의 불필요한 렌더링 방지를 위해 `memo` 및 `useCallback` 훅 적용
	- 이미지 업로드 로직 간소화 및 최적화
- **신규 기능**
	- 이미지 업로드 기능 추가 및 상태 관리 개선
	- 이미지 URL을 가져오는 새로운 비동기 함수 추가
	- 이미지 업로드를 처리하는 새로운 커스텀 훅 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->