### PR TITLE
[feat]여행이 날짜가 지났을때와 지나지 않았을 때에 대한 예약상태 표시 처리

### DIFF
--- a/src/components/myTravel/MyJoinedContent.tsx
+++ b/src/components/myTravel/MyJoinedContent.tsx
@@ -102,7 +102,7 @@ const MyJoinedContent = () => {
                 <Header>
                   <Title>{travelData.travelTitle}</Title>
                   {/* 예약이 거절된 상태면 "취소됨"을 표시, 아닌 경우 D-DAY 표시 */}
-                  {currentUser.status === 'refused' ? (
+                  {currentUser.status === 'rejected' ? (
                     <StatusCanceled>취소됨</StatusCanceled>
                   ) : (
                     <DaysRemaining>{daysRemaining}</DaysRemaining>
@@ -144,16 +144,17 @@ const MyJoinedContent = () => {
                         travelThumbnail={travelData.thumbnail}
                       />
                     )}
-
-                  {/* D-DAY이면서 후기가 작성된 경우 여행 완료 메시지 */}
-                  {isPast && reviewWritten && <CompletionMessage>여행 완료</CompletionMessage>}
-                  {isPast && currentUser.status === 'refused' && <p>예약 취소</p>}
-                  {/* 아직 D-DAY가 지나지 않은 경우 예약 상태 표시 */}
-                  {!isPast && (
+                  {isPast ? (
+                    <>
+                      {reviewWritten && <CompletionMessage>여행 완료</CompletionMessage>}
+                      {currentUser.status === 'rejected' && <p>예약 취소</p>}
+                      {currentUser.status === 'waiting' && <p>예약 불가</p>}
+                    </>
+                  ) : (
                     <>
                       {currentUser.status === 'approved' && <p>예약 완료</p>}
                       {currentUser.status === 'waiting' && <p>예약 대기</p>}
-                      {currentUser.status === 'refused' && <p>예약 취소</p>}
+                      {currentUser.status === 'rejected' && <p>예약 취소</p>}
                     </>
                   )}
                 </CurrentUserStatus>


### PR DESCRIPTION
## 📋 작업 세부 사항

여행이 날짜가 지났을때와 지나지 않았을 때에 대한 예약상태 표시 처리

## 🔧 변경 사항 요약

여행이 날짜가 지났을때와 지나지 않았을 때에 대한 예약상태 표시 처리

<!-- ## 📸 스크린샷 (선택 사항) -->

![image](https://github.com/user-attachments/assets/aa5d4894-1c11-4303-9321-3483056ad562)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 예약 상태 확인 조건을 수정하여, 올바른 예약 상태("거절됨")가 정확히 표시되도록 개선하였습니다.
  
- **리팩토링**
  - 사용자 예약 상태 메시지 렌더링 로직을 단순화해, 메시지 전달 흐름을 명료하게 개선하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->