### PR TITLE
Fix: alert 메시지를 toast로 교체,  여행글 작성후 travel-list쿼리키 무효화 #228 

### DIFF
--- a/src/components/addTravel/ChoiceTags.tsx
+++ b/src/components/addTravel/ChoiceTags.tsx
@@ -1,5 +1,6 @@
 import FiledBtn from '@/components/FiledBtn';
 import GrayBack from '@/components/GrayBack';
+import { ShowToast } from '@/components/Toast';
 import useAddTravelStore from '@/stores/useAddTravelStore';
 import { theme } from '@/styles/theme';
 import { TagType } from '@/types/tagType';
@@ -25,7 +26,7 @@ const ChoiceTags = () => {
 
   const handleTag = (tag: TagType) => {
     if (choseTag.length === 3 && !choseTag.includes(tag)) {
-      alert('태그는 최대 3개까지 선택 가능합니다.');
+      ShowToast('태그는 최대 3개까지 선택 가능합니다.', 'failed');
       return;
     }
     if (choseTag.includes(tag)) {

--- a/src/components/addTravel/FloatingMenu.tsx
+++ b/src/components/addTravel/FloatingMenu.tsx
@@ -1,6 +1,7 @@
 import useSectionsStore from '@/stores/useSectionsStore';
 import styled from '@emotion/styled';
 import { CircleMinus, CirclePlus } from 'lucide-react';
+import { memo } from 'react';
 import { useLocation } from 'react-router-dom';
 
 const ADD_FOR_FIND_GUIDE = 'add-for-find-guide';
@@ -9,7 +10,7 @@ interface FloatingMenuProps {
   onSubmit?: () => void;
 }
 
-const FloatingMenu = ({ onSubmit }: FloatingMenuProps) => {
+const FloatingMenu = memo(({ onSubmit }: FloatingMenuProps) => {
   const sections = useSectionsStore((state) => state.sections);
   const setOpenSection = useSectionsStore((state) => state.setOpenSection);
   const location = useLocation();
@@ -53,7 +54,7 @@ const FloatingMenu = ({ onSubmit }: FloatingMenuProps) => {
       </BottomButtons>
     </MenuContainer>
   );
-};
+});
 
 export default FloatingMenu;
 

--- a/src/components/addTravel/ScheduleTeam.tsx
+++ b/src/components/addTravel/ScheduleTeam.tsx
@@ -6,6 +6,7 @@ import Team from '@/components/Team';
 import { useLocation } from 'react-router-dom';
 import { formatDate } from '@/utils/format';
 import useComposing from '@/hooks/custom/useComposing';
+import { ShowToast } from '@/components/Toast';
 
 const ScheduleTeam = () => {
   const { setIsComposing, handleKeyDown } = useComposing();
@@ -18,7 +19,7 @@ const ScheduleTeam = () => {
 
   const handleAddSchedule = () => {
     if (scheduleList && scheduleList.length >= 4) {
-      alert('일정은 최대 4개까지 추가할 수 있습니다.');
+      ShowToast('일정은 최대 4개까지 추가할 수 있습니다.', 'failed');
       return;
     }
     if (startDateRef.current && endDateRef.current && membersRef.current) {

--- a/src/components/myReview/ReviewWriteModal.tsx
+++ b/src/components/myReview/ReviewWriteModal.tsx
@@ -51,11 +51,11 @@ const ReviewWriteModal = ({
   const handleFileUpload = (event: ChangeEvent<HTMLInputElement>) => {
     if (event.target.files) {
       if (!isValidFile(event.target.files[0])) {
-        alert('지원하지 않는 파일 형식입니다.');
+        ShowToast('지원하지 않는 파일 형식입니다.', 'failed');
         return;
       }
       if (files.length + event.target.files.length > 4) {
-        alert('파일은 최대 4개까지 업로드 가능합니다.');
+        ShowToast('파일은 최대 4개까지 업로드 가능합니다.', 'failed');
         return;
       }
       setFiles([...files, ...Array.from(event.target.files)]);

--- a/src/hooks/custom/useHandleAddTravel.ts
+++ b/src/hooks/custom/useHandleAddTravel.ts
@@ -17,7 +17,7 @@ const useHandleAddTravel = () => {
       travelContent: useFieldStore.getState().fields.content,
       travelTitle: useAddTravelStore.getState().data.travelTitle,
       thumbnail: null,
-      travelPrice: useAddTravelStore.getState().data.travelPrice,
+      travelPrice: useAddTravelStore.getState().data.travelPrice || 0,
       includedItems: useFieldStore.getState().fields.includeList,
       FAQ: useFieldStore.getState().fields.faqs,
       meetingTime: useFieldStore.getState().fields.meetingTime,
@@ -29,7 +29,7 @@ const useHandleAddTravel = () => {
     };
 
     if (!validateAddTravel(data)) return false;
-    if (data.travelPrice === 0) {
+    if (data.travelPrice === 0 || !data.travelPrice) {
       const modalStore = useModalStore.getState();
       modalStore.setModalName('zero-price-confirm');
       return false;

--- a/src/hooks/custom/useHandleAddTravel.ts
+++ b/src/hooks/custom/useHandleAddTravel.ts
@@ -1,54 +1,45 @@
 import useFieldStore from '@/stores/useFieldStore';
 import { validateAddTravel } from '@/utils/validCheck';
-import useImageStore from '@/stores/useImageStore';
-import useHandleImageUpload from '@/hooks/custom/useHandleImageUpload';
+
 import useCreateTravel from '@/hooks/query/useCreateTravel';
 import useAddTravelStore from '@/stores/useAddTravelStore';
+import useModalStore from '@/stores/useModalStore';
+import useUploadTravelImages from '@/hooks/custom/useUploadTravelImages';
+import { AddTravelData } from '@/types/travelDataType';
 
 const useHandleAddTravel = () => {
-  const setData = useAddTravelStore((state) => state.setData);
-  const images = useImageStore((state) => state.images);
-  const uploadImages = useHandleImageUpload().uploadImages;
+  const { upload } = useUploadTravelImages();
   const mutate = useCreateTravel().mutate;
 
-  const submitAddTravel = async () => {
-    const data = useAddTravelStore.getState().data;
+  const handleAddTravel = async () => {
+    const data: AddTravelData = {
+      userId: useAddTravelStore.getState().data.userId,
+      travelContent: useFieldStore.getState().fields.content,
+      travelTitle: useAddTravelStore.getState().data.travelTitle,
+      thumbnail: null,
+      travelPrice: useAddTravelStore.getState().data.travelPrice,
+      includedItems: useFieldStore.getState().fields.includeList,
+      FAQ: useFieldStore.getState().fields.faqs,
+      meetingTime: useFieldStore.getState().fields.meetingTime,
+      excludedItems: useFieldStore.getState().fields.excludeList,
+      meetingPlace: useAddTravelStore.getState().data.meetingPlace,
+      tag: useAddTravelStore.getState().data.tag,
+      team: useFieldStore.getState().fields.scheduleList,
+      travelCourse: useFieldStore.getState().fields.courseList,
+    };
 
-    if (validateAddTravel(data)) {
-      try {
-        const { thumbnail, meetingSpace } = await uploadImages(images);
-        setData({ thumbnail: thumbnail[0], meetingPlace: meetingSpace[0] });
-      } catch (error) {
-        console.error(error);
-        return false;
-      }
-
-      const updatedData = useAddTravelStore.getState().data;
-      if (!updatedData.thumbnail || updatedData.thumbnail.trim().length === 0) {
-        console.error('썸네일 등록에 오류가 있습니다.');
-        return false;
-      }
-
-      mutate(updatedData);
-    } else {
+    if (!validateAddTravel(data)) return false;
+    if (data.travelPrice === 0) {
+      const modalStore = useModalStore.getState();
+      modalStore.setModalName('zero-price-confirm');
       return false;
     }
-  };
 
-  const handleAddTravel = () => {
-    const { includeList, excludeList, faqs, courseList, meetingTime, scheduleList } =
-      useFieldStore.getState().fields;
+    const imageResult = await upload();
 
-    setData({
-      includedItems: includeList,
-      excludedItems: excludeList,
-      FAQ: faqs,
-      travelCourse: courseList,
-      meetingTime,
-      team: scheduleList,
-    });
+    if (!imageResult) return false;
 
-    submitAddTravel();
+    mutate({ ...data, ...imageResult });
   };
 
   return { handleAddTravel };

--- a/src/hooks/custom/useUploadTravelImages.ts
+++ b/src/hooks/custom/useUploadTravelImages.ts
@@ -1,0 +1,28 @@
+import useHandleImageUpload from '@/hooks/custom/useHandleImageUpload';
+import useImageStore from '@/stores/useImageStore';
+
+const useUploadTravelImages = () => {
+  const images = useImageStore((state) => state.images);
+  const uploadImages = useHandleImageUpload().uploadImages;
+
+  const upload = async () => {
+    try {
+      const { thumbnail, meetingSpace } = await uploadImages(images);
+      if (!thumbnail || thumbnail[0].trim().length === 0) {
+        console.error('썸네일 등록에 오류가 있습니다.');
+        return false;
+      }
+      return {
+        thumbnail: thumbnail[0],
+        meetingPlace: meetingSpace[0],
+      };
+    } catch (error) {
+      console.error(error);
+      return false;
+    }
+  };
+
+  return { upload };
+};
+
+export default useUploadTravelImages;

--- a/src/hooks/query/useCreateTravel.ts
+++ b/src/hooks/query/useCreateTravel.ts
@@ -1,24 +1,28 @@
 import createTravel from '@/api/addTravel/createTravel';
+import { ShowToast } from '@/components/Toast';
+import { TRAVEL_LIST } from '@/constants/queryKey';
 import useResetAddTravel from '@/hooks/custom/useResetAddTravel';
 
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
 const useCreateTravel = () => {
   const navigate = useNavigate();
   const resetAddTravel = useResetAddTravel().resetAddTravel;
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: createTravel,
     onSuccess: (data) => {
       if (data) {
-        alert('글 작성 완료');
+        ShowToast('글 작성 완료', 'success');
         resetAddTravel();
+        queryClient.invalidateQueries({ queryKey: [TRAVEL_LIST] });
         navigate('/travel-list');
       }
     },
     onError: () => {
-      alert('글 작성에 실패했습니다.');
+      ShowToast('글 작성에 실패했습니다.', 'failed');
     },
   });
 };

--- a/src/layouts/Auth.tsx
+++ b/src/layouts/Auth.tsx
@@ -46,6 +46,7 @@ const Auth: React.FC<{ light?: boolean }> = ({ light = false }) => {
         userScore,
       } = result.data.data;
       setUser({ userProfileImage, socialName, userEmail, isVerifiedUser, userId, userScore });
+      setUserProfileImage(userProfileImage);
     } catch (error) {
       console.error('로그인 처리에 오류가 발생했습니다.:', error);
     }

--- a/src/pages/AddTravel.tsx
+++ b/src/pages/AddTravel.tsx
@@ -41,7 +41,7 @@ const AddTravel = () => {
     },
 
     changePrice: (travelPrice: number) => {
-      setData({ travelPrice });
+      setData({ travelPrice: travelPrice === 0 ? null : travelPrice });
     },
   };
 
@@ -57,7 +57,7 @@ const AddTravel = () => {
       travelContent: useFieldStore.getState().fields.content,
       travelTitle: useAddTravelStore.getState().data.travelTitle,
       thumbnail: null,
-      travelPrice: useAddTravelStore.getState().data.travelPrice,
+      travelPrice: useAddTravelStore.getState().data.travelPrice || 0,
       includedItems: useFieldStore.getState().fields.includeList,
       FAQ: useFieldStore.getState().fields.faqs,
       meetingTime: useFieldStore.getState().fields.meetingTime,
@@ -97,8 +97,12 @@ const AddTravel = () => {
             css={noneStyleInput}
             type="number"
             placeholder="0"
+            step="1000"
+            max="10000000"
+            min="0"
             onChange={(e) => changeHandlers.changePrice(Number(e.target.value))}
-            value={data.travelPrice}
+            value={data.travelPrice || ''}
+            required
           />
           <span css={{ marginRight: '5px' }}>원</span>
           <span css={{ fontSize: '14px' }}>/ 1인</span>

--- a/src/pages/AddTravel.tsx
+++ b/src/pages/AddTravel.tsx
@@ -12,14 +12,24 @@ import useAddTravelStore from '@/stores/useAddTravelStore';
 import useHandleAddTravel from '@/hooks/custom/useHandleAddTravel';
 import useResetAddTravel from '@/hooks/custom/useResetAddTravel';
 import { useEffect } from 'react';
+import useModalStore from '@/stores/useModalStore';
+import ConfirmModal from '@/components/ConfirmModal';
+import useCreateTravel from '@/hooks/query/useCreateTravel';
+import useUploadTravelImages from '@/hooks/custom/useUploadTravelImages';
+import { ShowToast } from '@/components/Toast';
+import useFieldStore from '@/stores/useFieldStore';
+import { AddTravelData } from '@/types/travelDataType';
 
 const AddTravel = () => {
   const sections = useSectionsStore((state) => state.sections);
   const setData = useAddTravelStore((state) => state.setData);
   const data = useAddTravelStore((state) => state.data);
   const handleAddTravel = useHandleAddTravel().handleAddTravel;
-
   const resetAddTravel = useResetAddTravel().resetAddTravel;
+  const closeModal = useModalStore((state) => state.setModalName);
+
+  const uploadTravelImages = useUploadTravelImages().upload;
+  const mutate = useCreateTravel().mutate;
 
   useEffect(() => {
     resetAddTravel();
@@ -33,6 +43,35 @@ const AddTravel = () => {
     changePrice: (travelPrice: number) => {
       setData({ travelPrice });
     },
+  };
+
+  const handleConfirmZeroPrice = async () => {
+    closeModal(null);
+    const imageResult = await uploadTravelImages();
+    if (!imageResult) {
+      ShowToast('이미지가 업로드 되지 않았습니다.', 'failed');
+      return;
+    }
+    const data: AddTravelData = {
+      userId: useAddTravelStore.getState().data.userId,
+      travelContent: useFieldStore.getState().fields.content,
+      travelTitle: useAddTravelStore.getState().data.travelTitle,
+      thumbnail: null,
+      travelPrice: useAddTravelStore.getState().data.travelPrice,
+      includedItems: useFieldStore.getState().fields.includeList,
+      FAQ: useFieldStore.getState().fields.faqs,
+      meetingTime: useFieldStore.getState().fields.meetingTime,
+      excludedItems: useFieldStore.getState().fields.excludeList,
+      meetingPlace: useAddTravelStore.getState().data.meetingPlace,
+      tag: useAddTravelStore.getState().data.tag,
+      team: useFieldStore.getState().fields.scheduleList,
+      travelCourse: useFieldStore.getState().fields.courseList,
+    };
+    mutate({
+      ...data,
+      thumbnail: imageResult.thumbnail,
+      meetingPlace: imageResult.meetingPlace,
+    });
   };
 
   return (
@@ -72,6 +111,16 @@ const AddTravel = () => {
       </div>
 
       <FloatingMenu onSubmit={handleAddTravel} />
+      <ConfirmModal
+        modalId="zero-price-confirm"
+        trigger={<></>}
+        message={
+          <div css={{ fontWeight: '600', fontSize: '18px' }}>
+            여행 가격이 0원입니다. 계속 하시겠습니까?
+          </div>
+        }
+        onConfirm={handleConfirmZeroPrice}
+      />
     </div>
   );
 };

--- a/src/pages/TravelList.tsx
+++ b/src/pages/TravelList.tsx
@@ -10,14 +10,7 @@ import scrollToTop from '@/utils/scrollToTop';
 import useGetTravelList from '@/hooks/query/useGetTravelList';
 import { useCallback, useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { IGetTravelListReturn } from '@/api/travelList/getTravelList';
 import { TRAVEL_LIST } from '@/constants/queryKey';
-
-interface InfiniteQueryData<TPageData> {
-  pages: TPageData[];
-  pageParams: number[];
-}
-type TravelListInfiniteQueryData = InfiniteQueryData<IGetTravelListReturn>;
 
 const TravelList = () => {
   const queryClient = useQueryClient();
@@ -26,23 +19,12 @@ const TravelList = () => {
   const currentTag = tagDatas.find((data) => data.path === path) || { name: '전체', path: '전체' };
   const { name: pageTitle, path: searchTag } = currentTag;
 
-  const resetQueryData = useCallback(
-    (key: string) => {
-      queryClient.setQueryData<TravelListInfiniteQueryData>([TRAVEL_LIST, key], (data) => {
-        if (data) {
-          return {
-            pages: data.pages.slice(0, 1),
-            pageParams: data.pageParams.slice(0, 1),
-          };
-        }
-        return undefined;
-      });
-    },
-    [queryClient],
-  );
+  const resetQueryData = useCallback(() => {
+    queryClient.resetQueries({ queryKey: [TRAVEL_LIST] });
+  }, [queryClient]);
 
   useEffect(() => {
-    resetQueryData(searchTag);
+    resetQueryData();
   }, [searchTag, resetQueryData]);
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useGetTravelList({

--- a/src/stores/useAddTravelStore.ts
+++ b/src/stores/useAddTravelStore.ts
@@ -17,7 +17,7 @@ const initData = {
   travelCourse: null,
   tag: null,
   team: null,
-  travelPrice: 0,
+  travelPrice: null,
   includedItems: null,
   excludedItems: null,
   meetingTime: null,

--- a/src/types/travelDataType.ts
+++ b/src/types/travelDataType.ts
@@ -82,7 +82,7 @@ export interface AddTravelData {
   travelCourse: string[] | null;
   tag: TagType[] | null;
   team: Pick<TravelTeamData, 'personLimit' | 'travelStartDate' | 'travelEndDate'>[] | null;
-  travelPrice: number;
+  travelPrice: number | null;
   includedItems: string[] | null;
   excludedItems: string[] | null;
   meetingTime: string[] | null;

--- a/src/utils/validCheck.ts
+++ b/src/utils/validCheck.ts
@@ -1,3 +1,4 @@
+import { ShowToast } from '@/components/Toast';
 import { AddTravelData } from '@/types/travelDataType';
 
 export const isValidRatingNumber = (rating: number) => {
@@ -5,43 +6,36 @@ export const isValidRatingNumber = (rating: number) => {
 };
 
 export const validateAddTravel = (data: AddTravelData): boolean => {
-  const { userId, travelTitle, travelContent, travelCourse, tag, team, travelPrice } = data;
+  const { userId, travelTitle, travelContent, travelCourse, tag, team } = data;
 
   if (!userId || userId.trim().length === 0) {
-    alert('유저 ID는 필수입니다.');
+    ShowToast('유저 ID는 필수입니다.', 'failed');
     return false;
   }
 
   if (!travelTitle || travelTitle.trim().length === 0 || travelTitle.length > 30) {
-    alert('여행 제목은 필수이며 30자 이내여야 합니다.');
+    ShowToast('여행 제목은 필수이며 30자 이내여야 합니다.', 'failed');
     return false;
   }
 
   if (!travelContent || travelContent.trim().length === 0) {
-    alert('상품 소개는 필수입니다.');
+    ShowToast('상품 소개는 필수입니다.', 'failed');
     return false;
   }
 
   if (!Array.isArray(travelCourse) || travelCourse.length === 0) {
-    alert('여행 코스는 필수입니다.');
+    ShowToast('여행 코스는 필수입니다.', 'failed');
     return false;
   }
 
   if (!Array.isArray(tag) || tag.length === 0) {
-    alert('태그는 최소 1개 이상 선택해주세요.');
+    ShowToast('태그는 최소 1개 이상 선택해주세요.', 'failed');
     return false;
   }
 
   if (!Array.isArray(team) || team.length === 0) {
-    alert('팀 정보는 필수입니다.');
+    ShowToast('팀 정보는 필수입니다.', 'failed');
     return false;
-  }
-
-  if (travelPrice === 0) {
-    const userConfirmed = window.confirm('여행 가격이 0원입니다. 계속 하시겠습니까?');
-    if (!userConfirmed) {
-      return false;
-    }
   }
 
   return true;


### PR DESCRIPTION
## 📋 작업 세부 사항

- Fix/alert-to-toast-228
-  fix: 여행글 작성후 travel-list쿼리키 무효화 #228
- fix: alert 메시지를 toast로 교체 #228
<!-- 변경 사항이나 추가된 기능에 대해 자세히 설명해 주세요. -->

## 🔧 변경 사항 요약

<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- ## 📸 스크린샷 (선택 사항) -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- 신규 기능
	- 기존 경고창 대신 토스트 알림 기능이 도입되어, 태그 선택 제한, 스케줄 추가, 파일 업로드 오류 등에서 끊김 없는 피드백을 제공합니다.
	- 여행 등록 시 가격이 0인 경우 확인 모달이 활성화되어 추가 확인 절차를 진행합니다.
	- 사용자가 로그인 후 프로필 이미지를 즉시 반영할 수 있도록 기능이 추가되었습니다.
- 리팩터
	- 컴포넌트 렌더링이 최적화되어 사용자 인터페이스 반응성이 개선되었으며, 여행 등록 및 이미지 업로드 흐름이 보다 간결해졌습니다.
	- 여행 가격 필드의 초기값이 0에서 null로 변경되어, 가격 미설정 상태를 명확히 표현할 수 있게 되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->