### PR TITLE
[Fix] 여행카드 제목 클릭 시 해당 여행 글로 이동, 여행 글 작성 페이지에서 각 입력 컴포넌트 간의 여백 수정

### DIFF
--- a/src/components/GrayBack.tsx
+++ b/src/components/GrayBack.tsx
@@ -10,7 +10,7 @@ interface GrayBackProps {
 const GrayBack = ({ children, title, price = false, padding = true }: GrayBackProps) => {
   return (
     <>
-      <p css={{ fontSize: '18px', fontWeight: '600' }}>{title}</p>
+      <p css={{ fontSize: '18px', fontWeight: '600', paddingTop: padding ? '20px' : 0 }}>{title}</p>
       <div css={GrayBackWrapper(price, padding)}>{children}</div>
     </>
   );

--- a/src/components/myTravel/MyTravelCard.tsx
+++ b/src/components/myTravel/MyTravelCard.tsx
@@ -4,6 +4,7 @@ import Rating from '@/components/Rating';
 import { formatDate } from '@/utils/formatDate';
 import useUpdateTravelStatus from '@/hooks/query/useUpdateTravelStatus';
 import { useNavigate } from 'react-router-dom';
+import { css } from '@emotion/react';
 
 interface ITripCardProps {
   travelId: string;
@@ -45,7 +46,9 @@ const TripCard: React.FC<ITripCardProps> = ({
     >
       <TripInfo isDisabled={isDisabled}>
         <TitleContainer>
-          <Title>{title}</Title>
+          <h3 css={titleStyle} onClick={() => navigate(`/travel-detail/${travelId}`)}>
+            {title}
+          </h3>
           <Rating rating={Number(rating)} reviewCount={Number(reviews)} />
         </TitleContainer>
         <Price>
@@ -109,16 +112,17 @@ const DisabledText = styled.p<{ isHovered: boolean }>`
   cursor: ${(props) => (props.isHovered ? 'pointer' : 'default')};
 `;
 
+const titleStyle = css`
+  font-size: 18px;
+  font-weight: bold;
+  cursor: pointer;
+`;
+
 const TitleContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
   margin-bottom: 16px;
-`;
-
-const Title = styled.h3`
-  font-size: 18px;
-  font-weight: bold;
 `;
 
 const Price = styled.p`

--- a/src/components/myTravel/MyTravelContent.tsx
+++ b/src/components/myTravel/MyTravelContent.tsx
@@ -3,7 +3,7 @@ import TripCard from './MyTravelCard';
 import useUserStore from '@/stores/useUserStore';
 import useGetMyCreatedTravel from '@/hooks/query/useGetMyCreatedTravel';
 import { myCreatedTravel } from '@/types/myCreatedTravelType';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import BorderBtn from '../BorderBtn';
 import { IGetMyCreatedTravelReturn } from '@/api/myCreatedTravel/getMycreatedTravel';
 import { MY_CREATED_TRAVEL } from '@/constants/queryKey';
@@ -22,6 +22,7 @@ type MyCreatedInfiniteQueryData = InfiniteQueryData<IGetMyCreatedTravelReturn>;
 const MyCreatedContent = () => {
   const { user } = useUserStore((state) => state);
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   const resetQueryData = useCallback(
     (key: string) => {
@@ -89,8 +90,8 @@ const MyCreatedContent = () => {
       ) : (
         <EmptyMessage>
           여행을 생성해주세요
-          <BorderBtn color="#4a95f2">
-            <Link to="/add-travel">여행 만들기 +</Link>
+          <BorderBtn color="#4a95f2" onClick={() => navigate('/add-travel')}>
+            여행 만들기 +
           </BorderBtn>
         </EmptyMessage>
       )}

--- a/src/pages/FindGuideList.tsx
+++ b/src/pages/FindGuideList.tsx
@@ -7,10 +7,11 @@ import { css } from '@emotion/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 const FindGuide = () => {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   useEffect(() => {
     queryClient.resetQueries({ queryKey: [GUIDE_LIST] });
@@ -42,8 +43,8 @@ const FindGuide = () => {
     <div css={findGuideWrap}>
       <div className="page-title">
         <h2>가이드 찾아요</h2>
-        <BorderBtn color="#4a95f2">
-          <Link to="/add-for-find-guide">가이드 찾아요 +</Link>
+        <BorderBtn color="#4a95f2" onClick={() => navigate('/add-for-find-guide')}>
+          가이드 찾아요 +
         </BorderBtn>
       </div>
 


### PR DESCRIPTION
## 📋 작업 세부 사항

<!-- 변경 사항이나 추가된 기능에 대해 자세히 설명해 주세요. -->

## 🔧 변경 사항 요약

<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- ## 📸 스크린샷 (선택 사항) -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 여행 카드의 제목을 클릭하면 상세 페이지로 이동하는 인터랙션이 추가되었습니다.
- **Style**
	- 제목 영역의 여백이 조건부로 적용되어, 레이아웃의 유연성이 향상되었습니다.
- **Refactor**
	- 여행 추가 및 가이드 검색 관련 네비게이션 방식이 개선되어 사용자 경험이 보다 직관적으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->